### PR TITLE
Fix Javadoc grammar

### DIFF
--- a/net.resheim.eclipse.cc.ui/src/main/java/net/resheim/eclipse/cc/builder/KickAssemblerBuilder.java
+++ b/net.resheim.eclipse.cc.ui/src/main/java/net/resheim/eclipse/cc/builder/KickAssemblerBuilder.java
@@ -404,8 +404,8 @@ public class KickAssemblerBuilder extends IncrementalProjectBuilder {
 		}
 	}
 
-	/**
-	 * Clear KickAssembler problem markers for the file and all it's included files.
+        /**
+         * Clear KickAssembler problem markers for the file and all its included files.
 	 *
 	 * @param file the root file
 	 */


### PR DESCRIPTION
## Summary
- correct grammar in `KickAssemblerBuilder.clearMarkers` Javadoc

## Testing
- `mvn test` *(fails: `mvn: command not found`)*