### PR TITLE
Bump platform version to 2025-06

### DIFF
--- a/net.resheim.eclipse.cc/cc.product
+++ b/net.resheim.eclipse.cc/cc.product
@@ -154,8 +154,6 @@
       <feature id="org.eclipse.equinox.p2.rcp.feature" installMode="root"/>
       <feature id="org.eclipse.ecf.filetransfer.feature" installMode="root"/>
       <feature id="org.eclipse.ecf.filetransfer.httpclientjava.feature" installMode="root"/>
-      <feature id="org.eclipse.ecf.core.ssl.feature" installMode="root"/>
-      <feature id="org.eclipse.ecf.filetransfer.ssl.feature" installMode="root"/>
       <feature id="org.eclipse.e4.rcp" installMode="root"/>
       <feature id="org.eclipse.jgit.ssh.apache" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>

--- a/net.sourceforge.vice.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
+++ b/net.sourceforge.vice.cocoa.macosx.aarch64/META-INF/MANIFEST.MF
@@ -1,5 +1,5 @@
 Manifest-Version: 1.0
-Fragment-Host: net.sourceforge.vice;bundle-version="[3.8.0,4.0.0)"
+Fragment-Host: net.sourceforge.vice;bundle-version="[3.9.0,4.0.0)"
 Bundle-ManifestVersion: 2
 Bundle-Name: Versatile Commodore Emulator
 Bundle-SymbolicName: net.sourceforge.vice.cocoa.macosx.aarch64

--- a/net.sourceforge.vice/META-INF/p2.inf
+++ b/net.sourceforge.vice/META-INF/p2.inf
@@ -1,8 +1,0 @@
-requires.1.namespace = org.eclipse.equinox.p2.iu
-requires.1.name = net.sourceforge.vice.cocoa.macosx.aarch64
-requires.1.range = [$version$,$version$]
-requires.1.filter = (&(osgi.os=macosx)(osgi.ws=cocoa)(osgi.arch=aarch64)(!(org.eclipse.swt.buildtime=true)))
-requires.2.namespace = org.eclipse.equinox.p2.iu
-requires.2.name = net.sourceforge.vice.cocoa.macosx.x86_64
-requires.2.range = [$version$,$version$]
-requires.2.filter = (&(osgi.os=macosx)(osgi.ws=cocoa)(osgi.arch=x86_64)(!(org.eclipse.swt.buildtime=true)))

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
   </licenses>
 
   <properties>
-    <tycho.version>4.0.4</tycho.version>
+    <tycho.version>4.0.13</tycho.version>
     <maven.compiler.source>20</maven.compiler.source>
     <maven.compiler.target>20</maven.compiler.target>
     <org.eclipse.justj.jre.repository>https://download.eclipse.org/justj/jres/21/updates/nightly/latest</org.eclipse.justj.jre.repository>
@@ -55,8 +55,8 @@
       <layout>p2</layout>
     </repository>
     <repository>
-      <id>2024-09</id>
-      <url>https://download.eclipse.org/releases/2024-09/</url>
+      <id>2025-06</id>
+      <url>https://download.eclipse.org/releases/2025-06/</url>
       <layout>p2</layout>
     </repository>
   </repositories>


### PR DESCRIPTION
`org.eclipse.ecf.core.ssl.feature` appears to have disappeared. Removing it.