### PR TITLE
Clarify VICE runtime settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,8 @@ The screenshot above starts a named `.theia/launch.json` configuration, waits fo
 - launch and terminate VICE from Theia's built-in Run and Debug commands
 - Start Without Debugging through DAP `noDebug`, which starts VICE without the binary monitor
 - preference-backed external tool paths for installed VICE and Java:
-  `commodoreCommander.tools.viceExecutable`,
-  `commodoreCommander.tools.viceResourcesPath`, and
-  `commodoreCommander.tools.javaRuntime`
+  `commodoreCommander.VICE.runtimePath` selects a VICE runtime or installation
+  root, while `commodoreCommander.tools.javaRuntime` selects Java
 - Kick Assembler `.dbg` source mapping for source breakpoints, breakpoint locations, loaded sources, labels, and source-backed stack frame locations with nearest-line fallback and generated PRG-disassembly fallback
 - source breakpoints and memory data breakpoints/watchpoints through VICE binary-monitor checkpoints, including VICE checkpoint conditions and DAP-style hit conditions
 - logpoints/tracepoints for source lines, using non-stopping VICE checkpoints when the log message only needs static values and adapter-managed stop/log/resume when live register values are needed

--- a/bundled-docs/build-configuration.md
+++ b/bundled-docs/build-configuration.md
@@ -195,10 +195,15 @@ tools without changing shared project files:
 - `commodoreCommander.tools.javaRuntime`: Java command or path for Kick
   Assembler and SIDScore. `COMMODORE_COMMANDER_JAVA_RUNTIME` still takes
   precedence.
-- `commodoreCommander.tools.viceExecutable`: VICE executable command or path.
-  Launch configurations can still override this with `viceExecutable`.
-- `commodoreCommander.tools.viceResourcesPath`: VICE resources root containing
-  `share/vice`. Bundled runtimes use the same root for `bin`.
+- `commodoreCommander.VICE.runtimePath`: VICE runtime or installation root
+  containing `share/vice`. Leave it empty to use bundled VICE when available,
+  then standard system locations. When the root also contains `bin`, Commodore
+  Commander selects the emulator for the active machine profile, such as
+  `x64sc`, `x128`, or `xvic`.
+
+Launch configurations can still override one debug launch with `viceExecutable`
+and `viceResourcesPath`, but the normal Settings override is the runtime path
+because VICE is a suite of machine-specific emulators.
 
 ## Headless Build
 

--- a/bundled-docs/debugger-user-guide.md
+++ b/bundled-docs/debugger-user-guide.md
@@ -27,13 +27,18 @@ profile creates debug information:
 See [Build Configuration](build-configuration.md) for project and launch
 configuration details.
 
-If your platform does not have a bundled VICE runtime, set these preferences
-before launching:
+Commodore Commander uses bundled VICE when it is packaged for the current
+platform. To override that bundle, set this preference before launching:
 
-- `commodoreCommander.tools.viceExecutable`: VICE executable command or path,
-  such as `x64sc` or an absolute path to it.
-- `commodoreCommander.tools.viceResourcesPath`: VICE resources root containing
-  `share/vice`, used for bundled ROM images and monitor symbols.
+- `commodoreCommander.VICE.runtimePath`: VICE runtime or installation root
+  containing `share/vice`. When that root also contains `bin`, Commodore
+  Commander selects the VICE emulator for the active machine profile, such as
+  `x64sc`, `x128`, or `xvic`.
+
+You normally do not point Settings at one VICE executable because VICE is a
+suite of machine-specific emulators. For an exceptional single launch,
+`.theia/launch.json` can still set `viceExecutable` to a command or absolute
+path and `viceResourcesPath` to the matching runtime root.
 
 ## Start A Debug Session
 

--- a/packages/theia-extension/src/common/commodore-commander-tool-preferences.ts
+++ b/packages/theia-extension/src/common/commodore-commander-tool-preferences.ts
@@ -9,10 +9,18 @@ export const COMMODORE_COMMANDER_VICE_EXECUTABLE_PREFERENCE =
   'commodoreCommander.tools.viceExecutable';
 export const COMMODORE_COMMANDER_VICE_RESOURCES_PATH_PREFERENCE =
   'commodoreCommander.tools.viceResourcesPath';
+export const COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE =
+  'commodoreCommander.VICE.runtimePath';
+export const COMMODORE_COMMANDER_LEGACY_VICE_RUNTIME_PATH_PREFERENCE =
+  'commodoreCommander.vice.runtimePath';
 export const COMMODORE_COMMANDER_JAVA_RUNTIME_PREFERENCE =
   'commodoreCommander.tools.javaRuntime';
 
 export interface CommodoreCommanderToolPreferences {
+  /**
+   * VICE runtime root used by the debug adapter. The Settings UI exposes this
+   * as a runtime path because VICE is a suite of machine-specific emulators.
+   */
   viceExecutable?: string;
   viceResourcesPath?: string;
   javaRuntime?: string;
@@ -20,19 +28,36 @@ export interface CommodoreCommanderToolPreferences {
 
 export const COMMODORE_COMMANDER_TOOL_PREFERENCE_SCHEMA: PreferenceSchema = {
   scope: PreferenceScope.Folder,
-  title: 'Commodore Commander Tools',
+  title: 'Commodore Commander',
   properties: {
     [COMMODORE_COMMANDER_VICE_EXECUTABLE_PREFERENCE]: {
       type: 'string',
       default: '',
+      hidden: true,
       description:
-        'VICE executable command or absolute path. Leave empty to use the bundled emulator when available, otherwise the machine profile executable name.'
+        'Legacy VICE emulator command override. Use launch.json viceExecutable for a per-launch override.'
     },
     [COMMODORE_COMMANDER_VICE_RESOURCES_PATH_PREFERENCE]: {
       type: 'string',
       default: '',
+      hidden: true,
       description:
-        'VICE runtime resources root containing share/vice and, for bundled archives, bin. Leave empty to use the bundled platform runtime when available.'
+        `Legacy VICE resources path. Use ${COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE} instead.`
+    },
+    [COMMODORE_COMMANDER_LEGACY_VICE_RUNTIME_PATH_PREFERENCE]: {
+      type: 'string',
+      default: '',
+      hidden: true,
+      description:
+        `Legacy lowercase VICE runtime path. Use ${COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE} instead.`
+    },
+    [COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE]: {
+      type: 'string',
+      default: '',
+      markdownDescription:
+        'VICE runtime or installation root. Leave empty to use bundled VICE when available, then standard system locations. Set this to override bundled VICE. The directory must contain `share/vice`; when it also contains `bin`, Commodore Commander selects the machine profile emulator such as `x64sc`, `x128`, or `xvic`.',
+      description:
+        'VICE runtime or installation root containing share/vice. Leave empty to use bundled VICE when available, then standard system locations.'
     },
     [COMMODORE_COMMANDER_JAVA_RUNTIME_PREFERENCE]: {
       type: 'string',
@@ -52,6 +77,24 @@ export function getCommodoreCommanderToolPreferences(
   preferenceService: Pick<PreferenceService, 'get'>,
   resourceUri?: string
 ): CommodoreCommanderToolPreferences {
+  const viceResourcesPath = firstConfiguredPreference(
+    preferenceService.get<string>(
+      COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE,
+      '',
+      resourceUri
+    ),
+    preferenceService.get<string>(
+      COMMODORE_COMMANDER_LEGACY_VICE_RUNTIME_PATH_PREFERENCE,
+      '',
+      resourceUri
+    ),
+    preferenceService.get<string>(
+      COMMODORE_COMMANDER_VICE_RESOURCES_PATH_PREFERENCE,
+      '',
+      resourceUri
+    )
+  );
+
   return {
     ...optionalPreference(
       'viceExecutable',
@@ -63,11 +106,7 @@ export function getCommodoreCommanderToolPreferences(
     ),
     ...optionalPreference(
       'viceResourcesPath',
-      preferenceService.get<string>(
-        COMMODORE_COMMANDER_VICE_RESOURCES_PATH_PREFERENCE,
-        '',
-        resourceUri
-      )
+      viceResourcesPath
     ),
     ...optionalPreference(
       'javaRuntime',
@@ -88,4 +127,16 @@ function optionalPreference<K extends keyof CommodoreCommanderToolPreferences>(
   return normalized
     ? { [key]: normalized } as Pick<CommodoreCommanderToolPreferences, K>
     : {};
+}
+
+function firstConfiguredPreference(
+  ...values: Array<string | undefined>
+): string | undefined {
+  for (const value of values) {
+    const normalized = value?.trim();
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return undefined;
 }

--- a/packages/theia-extension/src/node/commodore-vice-debug-adapter-contribution.ts
+++ b/packages/theia-extension/src/node/commodore-vice-debug-adapter-contribution.ts
@@ -140,11 +140,11 @@ export class CommodoreViceDebugAdapterContribution
           },
           viceExecutable: {
             type: 'string',
-            description: 'VICE executable command or path. Overrides the Commodore Commander VICE executable preference.'
+            description: 'Advanced per-launch VICE emulator command or path. Usually leave unset so the selected machine profile chooses x64sc, x128, xvic, or another matching VICE emulator.'
           },
           viceResourcesPath: {
             type: 'string',
-            description: 'VICE runtime resources root containing share/vice. Overrides the Commodore Commander VICE resources preference.'
+            description: 'Per-launch VICE runtime root containing share/vice. Overrides the Commodore Commander VICE runtime path preference.'
           },
           viceArgs: {
             type: 'array',

--- a/packages/theia-extension/src/node/vice-runtime-resolver.ts
+++ b/packages/theia-extension/src/node/vice-runtime-resolver.ts
@@ -12,7 +12,7 @@ import {
   type CommodoreMachineProfileId
 } from '@commodore-commander/language-support';
 import {
-  COMMODORE_COMMANDER_VICE_RESOURCES_PATH_PREFERENCE
+  COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE
 } from '../common/commodore-commander-tool-preferences';
 
 export const VICE_DARWIN_ARM64_RESOURCES = path.join(
@@ -100,11 +100,14 @@ export async function resolveViceRuntime(
   const runtimeDirectory = options.runtimeDirectory ?? __dirname;
   const configuredResourcesPath = normalizeConfiguredPath(options.resourcesPath);
   const executable = normalizeConfiguredPath(options.executable);
+  const executableResourcesCandidates = executable
+    ? executableResourceCandidates(executable)
+    : [];
 
   const resourceCandidates = [
     ...(configuredResourcesPath ? [configuredResourcesPath] : []),
+    ...executableResourcesCandidates,
     ...bundledViceResourceCandidates(runtimeDirectory),
-    ...(executable ? executableResourceCandidates(executable) : []),
     ...systemViceResourceCandidates()
   ];
 
@@ -126,7 +129,7 @@ export async function resolveViceRuntime(
 
   throw new Error(
     `VICE runtime resources were not found for ${process.platform}-${process.arch}. ` +
-      `Set ${COMMODORE_COMMANDER_VICE_RESOURCES_PATH_PREFERENCE} to a directory containing ${VICE_RESOURCES_SUBDIRECTORY}.`
+      `Set ${COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE} to a VICE runtime root containing ${VICE_RESOURCES_SUBDIRECTORY}.`
   );
 }
 

--- a/packages/theia-extension/src/test/vice-runtime-resolver.test.ts
+++ b/packages/theia-extension/src/test/vice-runtime-resolver.test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  COMMODORE_COMMANDER_TOOL_PREFERENCE_SCHEMA,
+  COMMODORE_COMMANDER_LEGACY_VICE_RUNTIME_PATH_PREFERENCE,
+  COMMODORE_COMMANDER_VICE_EXECUTABLE_PREFERENCE,
+  COMMODORE_COMMANDER_VICE_RESOURCES_PATH_PREFERENCE,
+  COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE,
+  getCommodoreCommanderToolPreferences
+} from '../common/commodore-commander-tool-preferences';
+import {
+  resolveViceRuntime
+} from '../node/vice-runtime-resolver';
+
+test('VICE settings expose runtime path and hide legacy executable and resources preferences', () => {
+  const properties = COMMODORE_COMMANDER_TOOL_PREFERENCE_SCHEMA.properties;
+
+  assert.equal(
+    COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE,
+    'commodoreCommander.VICE.runtimePath'
+  );
+  assert.ok(properties[COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE]);
+  assert.equal(
+    properties[COMMODORE_COMMANDER_VICE_EXECUTABLE_PREFERENCE]?.hidden,
+    true
+  );
+  assert.equal(
+    properties[COMMODORE_COMMANDER_VICE_RESOURCES_PATH_PREFERENCE]?.hidden,
+    true
+  );
+  assert.equal(
+    properties[COMMODORE_COMMANDER_LEGACY_VICE_RUNTIME_PATH_PREFERENCE]?.hidden,
+    true
+  );
+});
+
+test('tool preferences prefer VICE runtime path and keep legacy fallbacks', () => {
+  const values = new Map<string, string>([
+    [COMMODORE_COMMANDER_VICE_RUNTIME_PATH_PREFERENCE, ' /new-vice '],
+    [COMMODORE_COMMANDER_VICE_RESOURCES_PATH_PREFERENCE, '/legacy-vice'],
+    [COMMODORE_COMMANDER_VICE_EXECUTABLE_PREFERENCE, ' x64sc-custom ']
+  ]);
+
+  const preferences = getCommodoreCommanderToolPreferences({
+    get: <T>(
+      preferenceName: string,
+      defaultValue?: T,
+      _resourceUri?: string
+    ): T | undefined =>
+      (values.has(preferenceName)
+        ? values.get(preferenceName)
+        : defaultValue) as T | undefined
+  });
+
+  assert.equal(preferences.viceResourcesPath, '/new-vice');
+  assert.equal(preferences.viceExecutable, 'x64sc-custom');
+});
+
+test('tool preferences keep legacy VICE resources path fallback', () => {
+  const values = new Map<string, string>([
+    [COMMODORE_COMMANDER_VICE_RESOURCES_PATH_PREFERENCE, ' /legacy-vice ']
+  ]);
+
+  const preferences = getCommodoreCommanderToolPreferences({
+    get: <T>(
+      preferenceName: string,
+      defaultValue?: T,
+      _resourceUri?: string
+    ): T | undefined =>
+      (values.has(preferenceName)
+        ? values.get(preferenceName)
+        : defaultValue) as T | undefined
+  });
+
+  assert.equal(preferences.viceResourcesPath, '/legacy-vice');
+});
+
+test('tool preferences keep lowercase VICE runtime path fallback', () => {
+  const values = new Map<string, string>([
+    [COMMODORE_COMMANDER_LEGACY_VICE_RUNTIME_PATH_PREFERENCE, ' /lowercase-vice ']
+  ]);
+
+  const preferences = getCommodoreCommanderToolPreferences({
+    get: <T>(
+      preferenceName: string,
+      defaultValue?: T,
+      _resourceUri?: string
+    ): T | undefined =>
+      (values.has(preferenceName)
+        ? values.get(preferenceName)
+        : defaultValue) as T | undefined
+  });
+
+  assert.equal(preferences.viceResourcesPath, '/lowercase-vice');
+});
+
+test('resolveViceRuntime prefers configured runtime path over bundled runtime', async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'cc-vice-runtime-'));
+
+  try {
+    const runtimeDirectory = path.join(tempRoot, 'app-runtime');
+    const bundledRoot = path.join(
+      runtimeDirectory,
+      'assets',
+      'vice',
+      `${process.platform}-${process.arch}`
+    );
+    const configuredRoot = path.join(tempRoot, 'configured-vice');
+
+    await mkdir(path.join(bundledRoot, 'share', 'vice'), { recursive: true });
+    await mkdir(path.join(configuredRoot, 'share', 'vice'), {
+      recursive: true
+    });
+
+    const resolved = await resolveViceRuntime({
+      runtimeDirectory,
+      resourcesPath: configuredRoot
+    });
+
+    assert.equal(resolved.resourcesPath, path.resolve(configuredRoot));
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('resolveViceRuntime prefers resources beside explicit executable path over bundled runtime', async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'cc-vice-runtime-'));
+
+  try {
+    const runtimeDirectory = path.join(tempRoot, 'app-runtime');
+    const bundledRoot = path.join(
+      runtimeDirectory,
+      'assets',
+      'vice',
+      `${process.platform}-${process.arch}`
+    );
+    const externalRoot = path.join(tempRoot, 'external-vice');
+    const externalExecutable = path.join(externalRoot, 'bin', 'x64sc');
+
+    await mkdir(path.join(bundledRoot, 'share', 'vice'), { recursive: true });
+    await mkdir(path.join(externalRoot, 'share', 'vice'), { recursive: true });
+
+    const resolved = await resolveViceRuntime({
+      runtimeDirectory,
+      executable: externalExecutable
+    });
+
+    assert.equal(resolved.resourcesPath, path.resolve(externalRoot));
+    assert.equal(resolved.executable, externalExecutable);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Clarifies how Commodore Commander selects and overrides VICE. Settings now expose a VICE runtime path instead of suggesting there is a single VICE executable, while legacy preference keys remain hidden compatibility fallbacks.

## Why

VICE is a suite of machine-specific emulator programs such as `x64sc`, `x128`, and `xvic`. The previous Settings labels for a global VICE executable/resources pair made that model unclear and could cause external executable overrides to keep using bundled resources.

## Changes

- Adds `commodoreCommander.VICE.runtimePath` as the visible VICE runtime override.
- Keeps the old VICE preference keys, plus the lowercase runtime key, hidden for compatibility.
- Makes explicit executable-path overrides prefer adjacent VICE resources before bundled resources.
- Updates launch schema copy and bundled docs to explain per-launch `viceExecutable` as an advanced override.
- Adds tests for Settings schema visibility, legacy fallbacks, runtime precedence, and executable-adjacent resource discovery.

## Validation

- `npm test --workspace @commodore-commander/theia-extension`