### PR TITLE
Improve SIDScore MIDI device detection diagnostics

### DIFF
--- a/packages/theia-extension/src/browser/sid-instrument-control-widget.tsx
+++ b/packages/theia-extension/src/browser/sid-instrument-control-widget.tsx
@@ -24,7 +24,7 @@ import {
   type SidScoreSidModel
 } from '../common/sidscore-runtime-service';
 import {
-  shouldScanMidiDevicesForModeActivation,
+  planMidiModeActivationSync,
   shouldStartInitialMidiDeviceScan
 } from './sid-instrument-midi-scan';
 import {
@@ -1223,15 +1223,17 @@ export class SidInstrumentControlWidget extends ReactWidget {
     this.midiMode = toMidiMode(value);
     this.midiEnabled = this.midiEnabledForCurrentMode();
     this.update();
-    if (shouldScanMidiDevicesForModeActivation({
+    const syncPlan = planMidiModeActivationSync({
       midiEnabled: this.midiEnabled,
       midiDeviceCount: this.midiDevices.length,
       midiScanning: this.midiScanning
-    })) {
+    });
+    if (syncPlan.scanDevices) {
       void this.scanMidiDevices();
-      return;
     }
-    this.queueMidiUpdate();
+    if (syncPlan.queueMidiSettings) {
+      this.queueMidiUpdate();
+    }
   }
 
   protected async scanMidiDevices(): Promise<void> {

--- a/packages/theia-extension/src/browser/sid-instrument-control-widget.tsx
+++ b/packages/theia-extension/src/browser/sid-instrument-control-widget.tsx
@@ -27,6 +27,12 @@ import {
   shouldScanMidiDevicesForModeActivation,
   shouldStartInitialMidiDeviceScan
 } from './sid-instrument-midi-scan';
+import {
+  DEFAULT_MIDI_MODE,
+  isMidiEnabledForMode,
+  toMidiMode,
+  type MidiModeId
+} from './sid-instrument-midi-mode';
 
 export const SID_INSTRUMENT_CONTROL_WIDGET_ID =
   'commodoreCommander.sidInstrumentControls';
@@ -34,7 +40,6 @@ export const SID_INSTRUMENT_CONTROL_WIDGET_ID =
 type WaveformId = 'triangle' | 'saw' | 'pulse' | 'noise';
 type ToggleId = 'ringMod' | 'sync' | 'hardRestart' | 'waveTable' | 'pulseTable' | 'filterTable';
 type FilterModeId = 'low' | 'band' | 'high';
-type MidiModeId = 'song' | 'instrument' | 'playAlong';
 
 const NUMERIC_DEFAULTS = {
   attack: 1,
@@ -495,8 +500,11 @@ export class SidInstrumentControlWidget extends ReactWidget {
   protected pendingInstrumentResetVoices = new Set<number>();
   protected readonly pendingInstrumentVoiceTimers = new Map<number, ReturnType<typeof setTimeout>>();
   protected scorePlaybackActive = false;
-  protected midiMode: MidiModeId = 'song';
-  protected midiEnabled = false;
+  protected midiMode: MidiModeId = DEFAULT_MIDI_MODE;
+  protected midiEnabled = isMidiEnabledForMode(
+    this.midiMode,
+    this.scorePlaybackActive
+  );
   protected midiScanning = false;
   protected initialMidiScanStarted = false;
   protected selectedMidiDeviceSelector = '';
@@ -1208,13 +1216,7 @@ export class SidInstrumentControlWidget extends ReactWidget {
   }
 
   protected midiEnabledForCurrentMode(): boolean {
-    if (this.midiMode === 'song') {
-      return false;
-    }
-    if (this.midiMode === 'instrument') {
-      return !this.scorePlaybackActive;
-    }
-    return true;
+    return isMidiEnabledForMode(this.midiMode, this.scorePlaybackActive);
   }
 
   protected setMidiMode(value: string): void {
@@ -1644,13 +1646,6 @@ function renderWaveformIcon(id: WaveformId): React.ReactNode {
 
 function buttonClass(active: boolean, disabled = false): string {
   return `cc-sid-button${active ? ' cc-sid-button--active' : ''}${disabled ? ' cc-sid-button--disabled' : ''}`;
-}
-
-function toMidiMode(value: string): MidiModeId {
-  if (value === 'instrument' || value === 'playAlong') {
-    return value;
-  }
-  return 'song';
 }
 
 function knobTitle(

--- a/packages/theia-extension/src/browser/sid-instrument-control-widget.tsx
+++ b/packages/theia-extension/src/browser/sid-instrument-control-widget.tsx
@@ -23,6 +23,10 @@ import {
   type SidScoreSetInstrumentRequest,
   type SidScoreSidModel
 } from '../common/sidscore-runtime-service';
+import {
+  shouldScanMidiDevicesForModeActivation,
+  shouldStartInitialMidiDeviceScan
+} from './sid-instrument-midi-scan';
 
 export const SID_INSTRUMENT_CONTROL_WIDGET_ID =
   'commodoreCommander.sidInstrumentControls';
@@ -549,7 +553,10 @@ export class SidInstrumentControlWidget extends ReactWidget {
   }
 
   async initializeMidiDevices(): Promise<void> {
-    if (this.initialMidiScanStarted) {
+    if (!shouldStartInitialMidiDeviceScan({
+      initialMidiScanStarted: this.initialMidiScanStarted,
+      midiScanning: this.midiScanning
+    })) {
       return;
     }
     this.initialMidiScanStarted = true;
@@ -615,6 +622,7 @@ export class SidInstrumentControlWidget extends ReactWidget {
   protected override onAfterAttach(msg: Message): void {
     super.onAfterAttach(msg);
     this.update();
+    void this.initializeMidiDevices();
   }
 
   protected override onUpdateRequest(msg: Message): void {
@@ -1213,6 +1221,14 @@ export class SidInstrumentControlWidget extends ReactWidget {
     this.midiMode = toMidiMode(value);
     this.midiEnabled = this.midiEnabledForCurrentMode();
     this.update();
+    if (shouldScanMidiDevicesForModeActivation({
+      midiEnabled: this.midiEnabled,
+      midiDeviceCount: this.midiDevices.length,
+      midiScanning: this.midiScanning
+    })) {
+      void this.scanMidiDevices();
+      return;
+    }
     this.queueMidiUpdate();
   }
 

--- a/packages/theia-extension/src/browser/sid-instrument-midi-mode.ts
+++ b/packages/theia-extension/src/browser/sid-instrument-midi-mode.ts
@@ -1,0 +1,23 @@
+export type MidiModeId = 'song' | 'instrument' | 'playAlong';
+
+export const DEFAULT_MIDI_MODE: MidiModeId = 'instrument';
+
+export function toMidiMode(value: string): MidiModeId {
+  if (value === 'song' || value === 'instrument' || value === 'playAlong') {
+    return value;
+  }
+  return DEFAULT_MIDI_MODE;
+}
+
+export function isMidiEnabledForMode(
+  mode: MidiModeId,
+  scorePlaybackActive: boolean
+): boolean {
+  if (mode === 'song') {
+    return false;
+  }
+  if (mode === 'instrument') {
+    return !scorePlaybackActive;
+  }
+  return true;
+}

--- a/packages/theia-extension/src/browser/sid-instrument-midi-scan.ts
+++ b/packages/theia-extension/src/browser/sid-instrument-midi-scan.ts
@@ -9,6 +9,11 @@ export interface MidiModeScanState {
   readonly midiScanning: boolean;
 }
 
+export interface MidiModeActivationSyncPlan {
+  readonly scanDevices: boolean;
+  readonly queueMidiSettings: boolean;
+}
+
 export function shouldStartInitialMidiDeviceScan(
   state: InitialMidiScanState
 ): boolean {
@@ -19,4 +24,13 @@ export function shouldScanMidiDevicesForModeActivation(
   state: MidiModeScanState
 ): boolean {
   return state.midiEnabled && state.midiDeviceCount === 0 && !state.midiScanning;
+}
+
+export function planMidiModeActivationSync(
+  state: MidiModeScanState
+): MidiModeActivationSyncPlan {
+  return {
+    scanDevices: shouldScanMidiDevicesForModeActivation(state),
+    queueMidiSettings: true
+  };
 }

--- a/packages/theia-extension/src/browser/sid-instrument-midi-scan.ts
+++ b/packages/theia-extension/src/browser/sid-instrument-midi-scan.ts
@@ -1,0 +1,22 @@
+export interface InitialMidiScanState {
+  readonly initialMidiScanStarted: boolean;
+  readonly midiScanning: boolean;
+}
+
+export interface MidiModeScanState {
+  readonly midiEnabled: boolean;
+  readonly midiDeviceCount: number;
+  readonly midiScanning: boolean;
+}
+
+export function shouldStartInitialMidiDeviceScan(
+  state: InitialMidiScanState
+): boolean {
+  return !state.initialMidiScanStarted && !state.midiScanning;
+}
+
+export function shouldScanMidiDevicesForModeActivation(
+  state: MidiModeScanState
+): boolean {
+  return state.midiEnabled && state.midiDeviceCount === 0 && !state.midiScanning;
+}

--- a/packages/theia-extension/src/browser/sidscore-protocol-log-widget.tsx
+++ b/packages/theia-extension/src/browser/sidscore-protocol-log-widget.tsx
@@ -14,6 +14,7 @@ export const SID_SCORE_PROTOCOL_LOG_WIDGET_ID =
 
 const MAX_PROTOCOL_LOG_ENTRIES = 500;
 const DEFAULT_IGNORE_HIGH_VOLUME_FRAMES = true;
+const TEXT_ENCODER = new TextEncoder();
 const IGNORED_HIGH_VOLUME_FRAME_TYPES = new Set([
   'SCOPE_SAMPLES',
   'VOICE_STATE'
@@ -260,5 +261,5 @@ function serverOutputLines(output: string): string[] {
 }
 
 function textByteLength(value: string): number {
-  return new TextEncoder().encode(value).length;
+  return TEXT_ENCODER.encode(value).length;
 }

--- a/packages/theia-extension/src/browser/sidscore-protocol-log-widget.tsx
+++ b/packages/theia-extension/src/browser/sidscore-protocol-log-widget.tsx
@@ -5,7 +5,8 @@ import { Message } from '@theia/core/lib/browser/widgets/widget';
 import { injectable } from '@theia/core/shared/inversify';
 
 import type {
-  SidScoreProtocolFrameEvent
+  SidScoreProtocolFrameEvent,
+  SidScoreServerOutputEvent
 } from '../common/sidscore-runtime-service';
 
 export const SID_SCORE_PROTOCOL_LOG_WIDGET_ID =
@@ -18,10 +19,23 @@ const IGNORED_HIGH_VOLUME_FRAME_TYPES = new Set([
   'VOICE_STATE'
 ]);
 
-interface SidScoreProtocolLogEntry extends SidScoreProtocolFrameEvent {
+interface SidScoreProtocolFrameLogEntry extends SidScoreProtocolFrameEvent {
   id: number;
+  kind: 'frame';
   receivedAt: number;
 }
+
+interface SidScoreServerOutputLogEntry {
+  id: number;
+  kind: 'serverOutput';
+  receivedAt: number;
+  stream: SidScoreServerOutputEvent['stream'];
+  output: string;
+}
+
+type SidScoreProtocolLogEntry =
+  | SidScoreProtocolFrameLogEntry
+  | SidScoreServerOutputLogEntry;
 
 @injectable()
 export class SidScoreProtocolLogWidget extends ReactWidget {
@@ -47,9 +61,33 @@ export class SidScoreProtocolLogWidget extends ReactWidget {
     this.entries.push({
       ...event,
       id: this.nextEntryId,
+      kind: 'frame',
       receivedAt: Date.now()
     });
     this.nextEntryId += 1;
+    if (this.entries.length > MAX_PROTOCOL_LOG_ENTRIES) {
+      this.entries = this.entries.slice(this.entries.length - MAX_PROTOCOL_LOG_ENTRIES);
+    }
+    this.update();
+  }
+
+  appendServerOutput(event: SidScoreServerOutputEvent): void {
+    const lines = serverOutputLines(event.output);
+    if (lines.length === 0) {
+      return;
+    }
+
+    const receivedAt = Date.now();
+    for (const output of lines) {
+      this.entries.push({
+        id: this.nextEntryId,
+        kind: 'serverOutput',
+        receivedAt,
+        stream: event.stream,
+        output
+      });
+      this.nextEntryId += 1;
+    }
     if (this.entries.length > MAX_PROTOCOL_LOG_ENTRIES) {
       this.entries = this.entries.slice(this.entries.length - MAX_PROTOCOL_LOG_ENTRIES);
     }
@@ -116,7 +154,7 @@ export class SidScoreProtocolLogWidget extends ReactWidget {
         <div className='cc-sidscore-protocol-log__body'>
           {this.entries.length > 0 ? this.renderTable() : (
             <div className='cc-sidscore-protocol-log__empty'>
-              No protocol messages
+              No protocol messages or server output
             </div>
           )}
         </div>
@@ -140,34 +178,65 @@ export class SidScoreProtocolLogWidget extends ReactWidget {
           </tr>
         </thead>
         <tbody>
-          {this.entries.map((entry) => (
-            <tr key={entry.id}>
-              <td title={entry.timestampNanos}>{formatTime(entry.receivedAt)}</td>
-              <td>
-                <span
-                  className={`cc-sidscore-protocol-log__direction cc-sidscore-protocol-log__direction--${entry.direction}`}
-                  title={entry.direction}
-                >
-                  {entry.direction === 'sent' ? 'TX' : 'RX'}
-                </span>
-              </td>
-              <td title={`0x${entry.type.toString(16).padStart(2, '0')}`}>
-                {entry.typeName}
-              </td>
-              <td>{entry.sequence}</td>
-              <td>{entry.requestId ?? '-'}</td>
-              <td>0x{entry.flags.toString(16).padStart(4, '0')}</td>
-              <td>{entry.payloadLength}</td>
-              <td
-                className='cc-sidscore-protocol-log__payload'
-                title={entry.payloadPreview}
-              >
-                {entry.payloadPreview || '-'}
-              </td>
-            </tr>
-          ))}
+          {this.entries.map((entry) => this.renderEntryRow(entry))}
         </tbody>
       </table>
+    );
+  }
+
+  protected renderEntryRow(entry: SidScoreProtocolLogEntry): React.ReactNode {
+    if (entry.kind === 'serverOutput') {
+      return (
+        <tr key={entry.id}>
+          <td>{formatTime(entry.receivedAt)}</td>
+          <td>
+            <span
+              className={`cc-sidscore-protocol-log__direction cc-sidscore-protocol-log__direction--${entry.stream}`}
+              title={`server ${entry.stream}`}
+            >
+              {entry.stream === 'stderr' ? 'ERR' : 'OUT'}
+            </span>
+          </td>
+          <td>SERVER_OUTPUT</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td>{textByteLength(entry.output)}</td>
+          <td
+            className='cc-sidscore-protocol-log__payload'
+            title={entry.output}
+          >
+            {entry.output}
+          </td>
+        </tr>
+      );
+    }
+
+    return (
+      <tr key={entry.id}>
+        <td title={entry.timestampNanos}>{formatTime(entry.receivedAt)}</td>
+        <td>
+          <span
+            className={`cc-sidscore-protocol-log__direction cc-sidscore-protocol-log__direction--${entry.direction}`}
+            title={entry.direction}
+          >
+            {entry.direction === 'sent' ? 'TX' : 'RX'}
+          </span>
+        </td>
+        <td title={`0x${entry.type.toString(16).padStart(2, '0')}`}>
+          {entry.typeName}
+        </td>
+        <td>{entry.sequence}</td>
+        <td>{entry.requestId ?? '-'}</td>
+        <td>0x{entry.flags.toString(16).padStart(4, '0')}</td>
+        <td>{entry.payloadLength}</td>
+        <td
+          className='cc-sidscore-protocol-log__payload'
+          title={entry.payloadPreview}
+        >
+          {entry.payloadPreview || '-'}
+        </td>
+      </tr>
     );
   }
 }
@@ -179,4 +248,17 @@ function formatTime(timestamp: number): string {
     date.getMinutes(),
     date.getSeconds()
   ].map((part) => part.toString().padStart(2, '0')).join(':');
+}
+
+function serverOutputLines(output: string): string[] {
+  return output
+    .replace(/\r\n/gu, '\n')
+    .replace(/\r/gu, '\n')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function textByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
 }

--- a/packages/theia-extension/src/browser/sidscore-runtime-contribution.ts
+++ b/packages/theia-extension/src/browser/sidscore-runtime-contribution.ts
@@ -427,6 +427,7 @@ export class SidScoreRuntimeContribution
     const output = event.output.trim();
     if (output.length > 0) {
       console.debug(`SIDScore server ${event.stream}: ${output}`);
+      this.getProtocolLogWidget()?.appendServerOutput(event);
     }
   }
 

--- a/packages/theia-extension/src/node/sidscore-launch.ts
+++ b/packages/theia-extension/src/node/sidscore-launch.ts
@@ -1,0 +1,78 @@
+export const SID_SCORE_CLI_JAR_FILENAME = 'sidscore-cli-0.6.0.jar';
+
+const MACOS_MIDI_SYSTEM_PROPERTIES = [
+  '-Djava.awt.headless=false',
+  '-Dapple.awt.UIElement=true',
+  '-Dsidscore.midi.awtEventPump=true'
+] as const;
+
+export interface SidScorePlayerServerArgsOptions {
+  readonly kickAssemblerJarPath: string;
+  readonly sidScoreCliJarPath: string;
+  readonly platform?: NodeJS.Platform;
+}
+
+export interface SidScoreLaunchDiagnosticOptions {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+  readonly env?: NodeJS.ProcessEnv;
+  readonly platform?: NodeJS.Platform;
+  readonly arch?: string;
+  readonly processExecPath?: string;
+}
+
+export function createSidScorePlayerServerArgs(
+  options: SidScorePlayerServerArgsOptions
+): string[] {
+  const platform = options.platform ?? process.platform;
+  return [
+    // The Theia instrument panel expects live MIDI to be audible immediately
+    // after settings changes. Waiting for a pre-audio note can miss input
+    // during device restarts and leave the monitor armed but silent.
+    '-Dsidscore.midi.monitor.startOnInput=false',
+    ...(platform === 'darwin' ? MACOS_MIDI_SYSTEM_PROPERTIES : []),
+    `-Dsidscore.kickass.jar=${options.kickAssemblerJarPath}`,
+    '-jar',
+    options.sidScoreCliJarPath,
+    '--player-server',
+    '--port',
+    '0'
+  ];
+}
+
+export function formatSidScoreLaunchDiagnostic(
+  options: SidScoreLaunchDiagnosticOptions
+): string {
+  const env = options.env ?? process.env;
+  return [
+    '[Commodore Commander] launching SIDScore player server',
+    `command=${formatCommandLine(options.command, options.args)}`,
+    `cwd=${quoteDiagnosticValue(options.cwd)}`,
+    `platform=${options.platform ?? process.platform}-${options.arch ?? process.arch}`,
+    `processExecPath=${quoteDiagnosticValue(options.processExecPath ?? process.execPath)}`,
+    `JAVA_HOME=${quoteDiagnosticValue(env.JAVA_HOME ?? '<unset>')}`,
+    `JAVA_TOOL_OPTIONS=${quoteDiagnosticValue(env.JAVA_TOOL_OPTIONS ?? '<unset>')}`,
+    `JDK_JAVA_OPTIONS=${quoteDiagnosticValue(env.JDK_JAVA_OPTIONS ?? '<unset>')}`,
+    `COMMODORE_COMMANDER_JAVA_RUNTIME=${quoteDiagnosticValue(
+      env.COMMODORE_COMMANDER_JAVA_RUNTIME ?? '<unset>'
+    )}`
+  ].join(' ');
+}
+
+export function formatCommandLine(
+  command: string,
+  args: readonly string[]
+): string {
+  return [command, ...args].map(quoteDiagnosticValue).join(' ');
+}
+
+function quoteDiagnosticValue(value: string): string {
+  if (value === '<unset>') {
+    return value;
+  }
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/u.test(value)) {
+    return value;
+  }
+  return `'${value.replace(/'/gu, `'\\''`)}'`;
+}

--- a/packages/theia-extension/src/node/sidscore-launch.ts
+++ b/packages/theia-extension/src/node/sidscore-launch.ts
@@ -51,11 +51,11 @@ export function formatSidScoreLaunchDiagnostic(
     `cwd=${quoteDiagnosticValue(options.cwd)}`,
     `platform=${options.platform ?? process.platform}-${options.arch ?? process.arch}`,
     `processExecPath=${quoteDiagnosticValue(options.processExecPath ?? process.execPath)}`,
-    `JAVA_HOME=${quoteDiagnosticValue(env.JAVA_HOME ?? '<unset>')}`,
-    `JAVA_TOOL_OPTIONS=${quoteDiagnosticValue(env.JAVA_TOOL_OPTIONS ?? '<unset>')}`,
-    `JDK_JAVA_OPTIONS=${quoteDiagnosticValue(env.JDK_JAVA_OPTIONS ?? '<unset>')}`,
-    `COMMODORE_COMMANDER_JAVA_RUNTIME=${quoteDiagnosticValue(
-      env.COMMODORE_COMMANDER_JAVA_RUNTIME ?? '<unset>'
+    `JAVA_HOME=${formatEnvironmentSignal(env.JAVA_HOME)}`,
+    `JAVA_TOOL_OPTIONS=${formatEnvironmentSignal(env.JAVA_TOOL_OPTIONS)}`,
+    `JDK_JAVA_OPTIONS=${formatEnvironmentSignal(env.JDK_JAVA_OPTIONS)}`,
+    `COMMODORE_COMMANDER_JAVA_RUNTIME=${formatEnvironmentSignal(
+      env.COMMODORE_COMMANDER_JAVA_RUNTIME
     )}`
   ].join(' ');
 }
@@ -75,4 +75,11 @@ function quoteDiagnosticValue(value: string): string {
     return value;
   }
   return `'${value.replace(/'/gu, `'\\''`)}'`;
+}
+
+function formatEnvironmentSignal(value: string | undefined): string {
+  if (value === undefined) {
+    return '<unset>';
+  }
+  return `<set:length=${value.length}>`;
 }

--- a/packages/theia-extension/src/node/sidscore-runtime-service-impl.ts
+++ b/packages/theia-extension/src/node/sidscore-runtime-service-impl.ts
@@ -52,8 +52,13 @@ import {
 import {
   getCommodoreCommanderToolPreferences
 } from '../common/commodore-commander-tool-preferences';
+import {
+  createSidScorePlayerServerArgs,
+  formatSidScoreLaunchDiagnostic,
+  SID_SCORE_CLI_JAR_FILENAME
+} from './sidscore-launch';
 
-export const SID_SCORE_CLI_JAR_FILENAME = 'sidscore-cli-0.6.0.jar';
+export { SID_SCORE_CLI_JAR_FILENAME } from './sidscore-launch';
 
 const SRAP_MAGIC = 0x53524150;
 const SRAP_VERSION = 1;
@@ -505,21 +510,26 @@ export class SidScoreRuntimeServiceImpl
     await assertReadable(kickAssemblerJarPath, 'KickAssembler jar');
 
     const command = javaCommand ?? await this.resolveJavaCommand();
-    const args = [
-      // The Theia instrument panel expects live MIDI to be audible immediately
-      // after settings changes. Waiting for a pre-audio note can miss input
-      // during device restarts and leave the monitor armed but silent.
-      '-Dsidscore.midi.monitor.startOnInput=false',
-      `-Dsidscore.kickass.jar=${kickAssemblerJarPath}`,
-      '-jar',
-      jarPath,
-      '--player-server',
-      '--port',
-      '0'
-    ];
+    const args = createSidScorePlayerServerArgs({
+      kickAssemblerJarPath,
+      sidScoreCliJarPath: jarPath
+    });
     this.serverCommand = command;
     this.serverArgs = args;
     this.serverCwd = process.cwd();
+
+    this.emitServerOutput(
+      'stdout',
+      `${formatSidScoreLaunchDiagnostic({
+        command,
+        args,
+        cwd: this.serverCwd,
+        env: process.env,
+        platform: process.platform,
+        arch: process.arch,
+        processExecPath: process.execPath
+      })}\n`
+    );
 
     const child = spawn(command, args, {
       cwd: this.serverCwd,

--- a/packages/theia-extension/src/test/sid-instrument-midi-mode.test.ts
+++ b/packages/theia-extension/src/test/sid-instrument-midi-mode.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEFAULT_MIDI_MODE,
+  isMidiEnabledForMode,
+  toMidiMode
+} from '../browser/sid-instrument-midi-mode';
+
+test('SID Instrument defaults MIDI mode to Instrument', () => {
+  assert.equal(DEFAULT_MIDI_MODE, 'instrument');
+  assert.equal(toMidiMode(''), 'instrument');
+  assert.equal(toMidiMode('unknown'), 'instrument');
+});
+
+test('SID Instrument preserves explicit MIDI mode selections', () => {
+  assert.equal(toMidiMode('song'), 'song');
+  assert.equal(toMidiMode('instrument'), 'instrument');
+  assert.equal(toMidiMode('playAlong'), 'playAlong');
+});
+
+test('SID Instrument enables MIDI according to playback mode', () => {
+  assert.equal(isMidiEnabledForMode('song', false), false);
+  assert.equal(isMidiEnabledForMode('song', true), false);
+  assert.equal(isMidiEnabledForMode('instrument', false), true);
+  assert.equal(isMidiEnabledForMode('instrument', true), false);
+  assert.equal(isMidiEnabledForMode('playAlong', false), true);
+  assert.equal(isMidiEnabledForMode('playAlong', true), true);
+});

--- a/packages/theia-extension/src/test/sid-instrument-midi-scan.test.ts
+++ b/packages/theia-extension/src/test/sid-instrument-midi-scan.test.ts
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  shouldScanMidiDevicesForModeActivation,
+  shouldStartInitialMidiDeviceScan
+} from '../browser/sid-instrument-midi-scan';
+
+test('SID Instrument starts one initial MIDI scan after attach', () => {
+  assert.equal(
+    shouldStartInitialMidiDeviceScan({
+      initialMidiScanStarted: false,
+      midiScanning: false
+    }),
+    true
+  );
+  assert.equal(
+    shouldStartInitialMidiDeviceScan({
+      initialMidiScanStarted: true,
+      midiScanning: false
+    }),
+    false
+  );
+  assert.equal(
+    shouldStartInitialMidiDeviceScan({
+      initialMidiScanStarted: false,
+      midiScanning: true
+    }),
+    false
+  );
+});
+
+test('SID Instrument scans before enabling MIDI with no known input devices', () => {
+  assert.equal(
+    shouldScanMidiDevicesForModeActivation({
+      midiEnabled: true,
+      midiDeviceCount: 0,
+      midiScanning: false
+    }),
+    true
+  );
+  assert.equal(
+    shouldScanMidiDevicesForModeActivation({
+      midiEnabled: true,
+      midiDeviceCount: 1,
+      midiScanning: false
+    }),
+    false
+  );
+  assert.equal(
+    shouldScanMidiDevicesForModeActivation({
+      midiEnabled: false,
+      midiDeviceCount: 0,
+      midiScanning: false
+    }),
+    false
+  );
+  assert.equal(
+    shouldScanMidiDevicesForModeActivation({
+      midiEnabled: true,
+      midiDeviceCount: 0,
+      midiScanning: true
+    }),
+    false
+  );
+});

--- a/packages/theia-extension/src/test/sid-instrument-midi-scan.test.ts
+++ b/packages/theia-extension/src/test/sid-instrument-midi-scan.test.ts
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  planMidiModeActivationSync,
   shouldScanMidiDevicesForModeActivation,
   shouldStartInitialMidiDeviceScan
 } from '../browser/sid-instrument-midi-scan';
@@ -62,5 +63,19 @@ test('SID Instrument scans before enabling MIDI with no known input devices', ()
       midiScanning: true
     }),
     false
+  );
+});
+
+test('SID Instrument keeps MIDI settings sync queued when scan is needed', () => {
+  assert.deepEqual(
+    planMidiModeActivationSync({
+      midiEnabled: true,
+      midiDeviceCount: 0,
+      midiScanning: false
+    }),
+    {
+      scanDevices: true,
+      queueMidiSettings: true
+    }
   );
 });

--- a/packages/theia-extension/src/test/sidscore-launch.test.ts
+++ b/packages/theia-extension/src/test/sidscore-launch.test.ts
@@ -41,13 +41,15 @@ test('SIDScore player server launch keeps macOS-only MIDI properties off other p
 });
 
 test('SIDScore launch diagnostic records command and Java environment signals', () => {
+  const javaHome = '/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home';
+  const javaToolOptions = '-Dhttp.proxyPassword=secret-token';
   const diagnostic = formatSidScoreLaunchDiagnostic({
     command: '/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java',
     args: ['-Djava.awt.headless=false', '-jar', '/Applications/Commodore Commander/sidscore-cli.jar'],
     cwd: '/Users/test/Commodore Project',
     env: {
-      JAVA_HOME: '/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home',
-      JAVA_TOOL_OPTIONS: '-Dexample=true'
+      JAVA_HOME: javaHome,
+      JAVA_TOOL_OPTIONS: javaToolOptions
     },
     platform: 'darwin',
     arch: 'arm64',
@@ -57,10 +59,18 @@ test('SIDScore launch diagnostic records command and Java environment signals', 
   assert.match(diagnostic, /^\[Commodore Commander\] launching SIDScore player server/u);
   assert.match(diagnostic, /command=/u);
   assert.match(diagnostic, /-Djava\.awt\.headless=false/u);
-  assert.match(diagnostic, /JAVA_HOME=/u);
-  assert.match(diagnostic, /JAVA_TOOL_OPTIONS=-Dexample=true/u);
+  assert.match(
+    diagnostic,
+    new RegExp(`JAVA_HOME=<set:length=${javaHome.length}>`, 'u')
+  );
+  assert.match(
+    diagnostic,
+    new RegExp(`JAVA_TOOL_OPTIONS=<set:length=${javaToolOptions.length}>`, 'u')
+  );
   assert.match(diagnostic, /JDK_JAVA_OPTIONS=<unset>/u);
   assert.match(diagnostic, /COMMODORE_COMMANDER_JAVA_RUNTIME=<unset>/u);
+  assert.doesNotMatch(diagnostic, /secret-token/u);
+  assert.doesNotMatch(diagnostic, /proxyPassword/u);
 });
 
 test('SIDScore launch command formatting quotes paths with spaces', () => {

--- a/packages/theia-extension/src/test/sidscore-launch.test.ts
+++ b/packages/theia-extension/src/test/sidscore-launch.test.ts
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  createSidScorePlayerServerArgs,
+  formatCommandLine,
+  formatSidScoreLaunchDiagnostic
+} from '../node/sidscore-launch';
+
+test('SIDScore player server launch enables macOS MIDI event pump before jar execution', () => {
+  const args = createSidScorePlayerServerArgs({
+    kickAssemblerJarPath: '/Applications/Commodore Commander/KickAss.jar',
+    sidScoreCliJarPath: '/Applications/Commodore Commander/sidscore-cli.jar',
+    platform: 'darwin'
+  });
+
+  const jarIndex = args.indexOf('-jar');
+
+  assert.ok(jarIndex > 0);
+  assert.ok(args.indexOf('-Djava.awt.headless=false') > -1);
+  assert.ok(args.indexOf('-Dapple.awt.UIElement=true') > -1);
+  assert.ok(args.indexOf('-Dsidscore.midi.awtEventPump=true') > -1);
+  assert.ok(args.indexOf('-Djava.awt.headless=false') < jarIndex);
+  assert.ok(args.indexOf('-Dapple.awt.UIElement=true') < jarIndex);
+  assert.ok(args.indexOf('-Dsidscore.midi.awtEventPump=true') < jarIndex);
+  assert.equal(args[jarIndex + 1], '/Applications/Commodore Commander/sidscore-cli.jar');
+  assert.deepEqual(args.slice(-3), ['--player-server', '--port', '0']);
+});
+
+test('SIDScore player server launch keeps macOS-only MIDI properties off other platforms', () => {
+  const args = createSidScorePlayerServerArgs({
+    kickAssemblerJarPath: '/opt/commodore/KickAss.jar',
+    sidScoreCliJarPath: '/opt/commodore/sidscore-cli.jar',
+    platform: 'linux'
+  });
+
+  assert.equal(args.includes('-Djava.awt.headless=false'), false);
+  assert.equal(args.includes('-Dapple.awt.UIElement=true'), false);
+  assert.equal(args.includes('-Dsidscore.midi.awtEventPump=true'), false);
+  assert.ok(args.includes('-Dsidscore.midi.monitor.startOnInput=false'));
+});
+
+test('SIDScore launch diagnostic records command and Java environment signals', () => {
+  const diagnostic = formatSidScoreLaunchDiagnostic({
+    command: '/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java',
+    args: ['-Djava.awt.headless=false', '-jar', '/Applications/Commodore Commander/sidscore-cli.jar'],
+    cwd: '/Users/test/Commodore Project',
+    env: {
+      JAVA_HOME: '/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home',
+      JAVA_TOOL_OPTIONS: '-Dexample=true'
+    },
+    platform: 'darwin',
+    arch: 'arm64',
+    processExecPath: '/Applications/Commodore Commander.app/Contents/MacOS/Commodore Commander'
+  });
+
+  assert.match(diagnostic, /^\[Commodore Commander\] launching SIDScore player server/u);
+  assert.match(diagnostic, /command=/u);
+  assert.match(diagnostic, /-Djava\.awt\.headless=false/u);
+  assert.match(diagnostic, /JAVA_HOME=/u);
+  assert.match(diagnostic, /JAVA_TOOL_OPTIONS=-Dexample=true/u);
+  assert.match(diagnostic, /JDK_JAVA_OPTIONS=<unset>/u);
+  assert.match(diagnostic, /COMMODORE_COMMANDER_JAVA_RUNTIME=<unset>/u);
+});
+
+test('SIDScore launch command formatting quotes paths with spaces', () => {
+  assert.equal(
+    formatCommandLine('/usr/bin/java', ['-jar', '/Applications/Commodore Commander/sidscore-cli.jar']),
+    "/usr/bin/java -jar '/Applications/Commodore Commander/sidscore-cli.jar'"
+  );
+});


### PR DESCRIPTION
## What changed

- Start the SIDScore player server on macOS with the Java AWT/CoreMIDI-related properties before -jar so they apply at JVM startup.
- Add a SIDScore launch diagnostic line that records the Java command, working directory, platform, Electron process path, and relevant Java environment variables.
- Show SIDScore server stdout/stderr rows in the existing SIDScore Protocol view when that view is open.
- Default the SID Instrument MIDI mode to Instrument, which is the useful live-keyboard mode when no SIDScore is playing.
- Trigger an initial MIDI scan when the SID Instrument widget is attached, and scan before enabling MIDI mode when no MIDI devices are known.
- Add focused tests for MIDI mode defaults, MIDI scan gating, and SIDScore launch argument construction/diagnostics.

## Why

The Arturia MicroLab is visible to macOS and to the bundled SIDScore CLI when run directly, but the app-launched SIDScore player server can reply to SCAN_MIDI_DEVICES with an empty MIDI_DEVICE_LIST. This keeps the functional launch setup explicit for macOS and makes the next in-app trace show the actual Java runtime context and SIDScore server scan logs instead of only SRAP frames.

The default MIDI mode should also favor live instrument input. Song only and Play along are useful around SIDScore playback, while Instrument is the expected default for a plugged-in keyboard before any score is playing.

## Validation

- npm run test --workspace @commodore-commander/theia-extension
- Hardware check with the keyboard plugged in: java ... -jar resources/sidscore-cli-0.6.0.jar --list-midi-devices reports MicroLab mk3.
- Hardware check with /usr/bin/java ... --list-midi-devices also reports MicroLab mk3.
