### PR TITLE
Add editing user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,40 +10,17 @@ The _Commodore Commander_ aims to be a useful addition to this ecosystem of tool
 
 ![Theia 6502 mnemonic reference hover](docs/theia-mnemonic-hover.png)
 
-Supported editor features:
+Commodore Commander adds Kick Assembler language support to Theia, including
+syntax highlighting, symbol/directive/include completion, 6502 mnemonic help,
+hover/reference navigation, rename, outline/workspace symbols, semantic
+highlighting, folding, formatting, and quick fixes. The Active Machine selector
+filters machine-specific reference symbols and feeds the emulator-oriented
+workflow used by builds and debugging.
 
-- syntax highlighting and language configuration for Kick Assembler source files
-- symbol completion for labels, constants, variables, namespaces, macros, functions, structs, enums, and generated structural symbols
-- directive completion for `.byte`, `.const`, `.macro`, `.segment`, `#import`, `#importonce`, and related Kick Assembler directives
-- include-path completion from the current folder and workspace Kick Assembler files
-- 6502 mnemonic completion plus addressing-mode snippets such as `#$00`, `$0000,x`, and `($00),y`
-- hover, go to definition, and find references for project symbols, 6502 mnemonics, and C64 I/O reference symbols
-- rename symbol across the current workspace scan
-- document symbols, workspace symbols, semantic highlighting, folding, document formatting, and quick fixes
-- Kick Assembler builds with project configuration for named programs, build profiles, library roots, output folders, debug/symbol switches, generated assets, discovered standalone assembly files, and headless CI use
-
-Using the editor features:
-
-- Content assist is available with **Ctrl+Space** and also appears while typing common Kick Assembler triggers such as `.`, `#`, `"`, `/`, and 6502 mnemonic operands. It suggests directives, labels, constants, variables, macros, include paths, 6502 mnemonics, and only the addressing modes valid for the selected mnemonic when the bundled 6502 reference is loaded.
-- Mnemonic content assist is backed by `packages/language-support/reference/6502.xml`. The details panel includes the mnemonic description, affected flags, legal addressing modes, example syntax, and opcode values from that reference.
-- Cmd-click a symbol or 6502 mnemonic on macOS, or Ctrl-click on Windows/Linux, to jump to its definition/reference entry. The same lookup is available from the context menu with **Go to Definition**.
-- **Find References** lists project uses for labels and symbols, plus reference occurrences for known 6502 mnemonics and C64 I/O symbols.
-- Hover a 6502 mnemonic or C64 I/O symbol to see the reference entry inline. Mnemonic hovers include opcode tables and diagrams where the bundled reference provides them.
-- **Rename Symbol** updates labels and supported Kick Assembler symbols across the current workspace scan. It intentionally does not rewrite text inside comments or string literals.
-- The outline and workspace symbol commands expose labels, constants, variables, namespaces, macros, functions, structs, enums, segments, and other structural symbols.
-- Document formatting normalizes indentation inside blocks and spacing around common declarations while preserving source order and comments.
-- Folding groups namespaces, macros, functions, structs, enums, conditional blocks, block comments, and import runs.
-- Quick fixes currently focus on structural source repairs such as converting unquoted import paths to canonical quoted `#import "..."` form.
-
-Build configuration:
-
-- The Theia build service and the headless CLI read `commodore-commander.build.json`, `.commodore-commander.build.json`, or `.commodore-commander/build.json` from the workspace root.
-- The config supports named programs, profiles, optional runs, configurable KickAss and Java runtimes, multiple library roots, output folders, run-program paths, symbol/debug flags, custom assembler arguments, explicit root programs, optional program machine sections, and generated-asset rebuild triggers.
-- Missing workspace configs, explicit default profiles, and standalone programs are created on demand by the Theia backend; the status bar exposes the active build profile picker.
-- Running and debugging now use Theia's native Start Debugging and Start Without Debugging commands with `commodore-vice` launch configurations.
-- From an active assembler source, F5/Ctrl+F5 can offer to create or append a matching `.theia/launch.json` entry and then start it through Theia's debug session manager.
-- Generated launch entries use a program or run `machine` override when one is configured. Without one, the debug adapter falls back to the default C64 profile; wiring the workspace Active Machine into generated launch entries is still future task/launch work.
-- The right toolbar exposes Active Machine selection for reference filtering and machine-profile UI.
+For day-to-day source editing workflows, see
+[Editing User Guide](bundled-docs/editing-user-guide.md). Build profiles,
+program discovery, generated launch entries, and headless use are covered in
+[Build Configuration](bundled-docs/build-configuration.md).
 
 ## Character set editor
 

--- a/bundled-docs/editing-user-guide.md
+++ b/bundled-docs/editing-user-guide.md
@@ -1,0 +1,102 @@
+# Editing User Guide
+
+This guide covers source editing for Kick Assembler projects in Commodore
+Commander. Character sets, screens, sprites, SIDScore, and debugging have their
+own guides.
+
+## Open A Source File
+
+Open a Kick Assembler source file from the workspace. Commodore Commander
+assigns the Kick Assembler language mode to recognized assembler files and
+scans the workspace for symbols, imports, and bundled reference entries.
+
+The workspace scan skips tool folders such as `.git`, `.metadata`, `.theia`,
+`node_modules`, and `target` so lookup results stay focused on project source
+files.
+
+Use the Active Machine selector in the right toolbar when you want reference
+features to follow a specific Commodore profile. This affects machine-specific
+reference symbols such as C64 I/O addresses.
+
+## Completion
+
+Use **Ctrl+Space** to request completion. Completion also appears while typing
+common Kick Assembler triggers such as `.`, `#`, quoted import paths, path
+separators, and 6502 mnemonic operands.
+
+The editor can suggest:
+
+- Kick Assembler directives and preprocessor directives
+- labels, constants, variables, namespaces, macros, functions, structs, enums,
+  and segments found in the workspace
+- include paths from the current directory and other workspace source files
+- 6502 mnemonics
+- addressing-mode snippets such as `#$00`, `$0000,x`, and `($00),y`
+
+Mnemonic completions use the bundled 6502 reference. When available, the
+completion detail includes mnemonic descriptions, affected flags, legal
+addressing modes, example syntax, and opcode values.
+
+## Reference Help
+
+Hover over a known 6502 mnemonic or machine reference symbol to see inline
+documentation. Mnemonic hovers include opcode tables and diagrams when the
+bundled reference provides them.
+
+Use Cmd-click on macOS, Ctrl-click on Windows or Linux, or the editor context
+menu's **Go to Definition** action to jump to a project declaration or bundled
+reference entry.
+
+Use **Find References** to list project uses of labels and symbols. Known 6502
+mnemonics and machine reference symbols also report reference occurrences from
+the current workspace scan.
+
+Use workspace symbols when you need to jump by name across the project. The
+symbol list includes labels, constants, variables, namespaces, macros,
+functions, structs, enums, segments, and generated structural symbols.
+
+## Rename
+
+Use **Rename Symbol** on supported project symbols to update the current
+workspace scan. Rename is intended for source symbols and intentionally avoids
+rewriting text inside comments or string literals.
+
+After a large rename, save the affected files and check the build output. The
+rename engine is conservative, but assembler projects often use generated names,
+string-based references, or macro conventions that deserve a build pass.
+
+## Source Structure
+
+The outline view shows labels, declarations, namespaces, macros, functions,
+structs, enums, segments, and related structural symbols for the active source
+file.
+
+Folding groups namespaces, macros, functions, structs, enums, conditional
+blocks, block comments, and runs of imports.
+
+Document formatting normalizes indentation inside blocks and spacing around
+common declarations while preserving source order and comments.
+
+Quick fixes currently focus on structural source repairs, such as converting an
+unquoted import path to canonical `#import "..."` form.
+
+Semantic highlighting distinguishes source symbols, directives, mnemonics,
+numbers, strings, comments, and known reference entries when the editor theme
+uses semantic colors.
+
+## Build Feedback While Editing
+
+Saving a workspace `.asm` file triggers the Kick Assembler build service for the
+active workspace build profile. Build output appears in the Kick Assembler
+console, and compiler diagnostics are applied to the Problems view and source
+editor.
+
+The status bar shows the active build profile for the current Kick Assembler
+source. Select it to choose another profile or create a new one. See
+[Build Configuration](build-configuration.md) for workspace build files,
+profiles, named programs, generated assets, and headless build use.
+
+Use **F5** or **Ctrl+F5** from an active assembler source to create or reuse a
+matching launch configuration and start the program through Theia's debug
+session manager. See [Debugger User Guide](debugger-user-guide.md) for runtime
+and breakpoint workflows.

--- a/bundled-docs/keyboard-mapping.md
+++ b/bundled-docs/keyboard-mapping.md
@@ -8,6 +8,8 @@ currently supporting: C64, C64DTV, C128, VIC-20, Plus/4, C16, PET, CBM-II, and
 CBM 5x0 profiles all expose a Commodore keyboard layout. Some of the detailed
 translation rules below are C64-family specific because VICE exposes compatible
 SDL/key-matrix behavior for those machines.
+The embedded keyboard mapper is not a C64-only tool; it follows the active
+Commodore machine profile where the profile exposes enough keyboard detail.
 
 This matters on non-US layouts. On a Nordic ISO Mac keyboard, for example,
 Shift+0 produces `=`, so the embedded emulator receives the Commodore `=` key.

--- a/packages/theia-extension/src/browser/commodore-commander-bundled-docs.ts
+++ b/packages/theia-extension/src/browser/commodore-commander-bundled-docs.ts
@@ -61,6 +61,11 @@ export interface BundledDocumentationEntry {
 // copied into the product, but should not appear as standalone help items.
 export const BUNDLED_DOCUMENTS: readonly BundledDocumentationEntry[] = [
   {
+    path: 'editing-user-guide.md',
+    label: 'Editing User Guide',
+    details: 'Source editing, lookup, rename and build feedback workflows'
+  },
+  {
     path: 'build-configuration.md',
     label: 'Build Configuration',
     details: 'How to configure profiles, targets and launching'

--- a/packages/theia-extension/src/test/bundled-documentation.test.ts
+++ b/packages/theia-extension/src/test/bundled-documentation.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { access, readFile } from 'node:fs/promises';
+import { access, readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { test } from 'node:test';
 
@@ -44,7 +44,34 @@ test('bundled documentation registry includes the embedded keyboard mapping guid
   assert.match(guide, /commodoreCommander\.emulator\.viceMenuShortcut/u);
 });
 
-test('registered bundled Markdown documents exist in bundled-docs', async () => {
+test('bundled documentation registry includes the editing user guide', async () => {
+  const registrySource = await readFile(
+    path.resolve(
+      __dirname,
+      '..',
+      '..',
+      'src',
+      'browser',
+      'commodore-commander-bundled-docs.ts'
+    ),
+    'utf8'
+  );
+  const docsRoot = path.resolve(__dirname, '..', '..', '..', '..', 'bundled-docs');
+
+  assert.match(registrySource, /path:\s*'editing-user-guide\.md'/u);
+  assert.match(registrySource, /label:\s*'Editing User Guide'/u);
+  await access(path.join(docsRoot, 'editing-user-guide.md'));
+
+  const guide = await readFile(path.join(docsRoot, 'editing-user-guide.md'), 'utf8');
+  assert.match(guide, /Ctrl\+Space/u);
+  assert.match(guide, /Go to Definition/u);
+  assert.match(guide, /Find References/u);
+  assert.match(guide, /Rename Symbol/u);
+  assert.match(guide, /Active Machine/u);
+  assert.match(guide, /Build Configuration/u);
+});
+
+test('all bundled Markdown documents are registered and exist in bundled-docs', async () => {
   const registrySource = await readFile(
     path.resolve(
       __dirname,
@@ -60,9 +87,13 @@ test('registered bundled Markdown documents exist in bundled-docs', async () => 
   const registeredMarkdownPaths = Array.from(
     registrySource.matchAll(/path:\s*'([^']+\.md)'/gu),
     match => match[1]
-  );
+  ).sort();
+  const bundledMarkdownPaths = (await readdir(docsRoot))
+    .filter(entry => entry.endsWith('.md'))
+    .sort();
 
   assert.ok(registeredMarkdownPaths.length > 0);
+  assert.deepEqual(registeredMarkdownPaths, bundledMarkdownPaths);
   for (const relativePath of registeredMarkdownPaths) {
     await access(path.join(docsRoot, relativePath));
   }


### PR DESCRIPTION
## Summary

- Shortens the README Editor support section to a concise overview with links to detailed guides.
- Adds a bundled Editing User Guide for Kick Assembler source editing workflows.
- Registers the new guide in the shared bundled documentation list so it appears in the welcome-page Help section and the main Help > Documentation menu.
- Extends bundled documentation tests so every bundled Markdown guide must be registered.
- Adds the keyboard-mapping guide sentence required by the existing documentation test.
